### PR TITLE
Quick Shell Script fix

### DIFF
--- a/build-libssh2.sh
+++ b/build-libssh2.sh
@@ -92,7 +92,7 @@ do
 	LOG="${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk/build-libssh2-${VERSION}.log"
 	echo ${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk
 	
-	if [ $1 == "openssl" ];
+	if [ "$1" == "openssl" ];
 	then
 		./configure --host=${ARCH}-apple-darwin --prefix="${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk" -with-openssl --with-libssl-prefix=${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk --disable-shared --enable-static  >> "${LOG}" 2>&1
 	else


### PR DESCRIPTION
Quick fix for syntax error in build-libssh2.sh when called with no arguments.
