### PR TITLE
Update libSSH URL to use HTTPS

### DIFF
--- a/build-libssh2.sh
+++ b/build-libssh2.sh
@@ -34,7 +34,7 @@ DEVELOPER=`xcode-select -print-path`
 set -e
 if [ ! -e libssh2-${VERSION}.tar.gz ]; then
 	echo "Downloading libssh2-${VERSION}.tar.gz"
-    curl -O http://www.libssh2.org/download/libssh2-${VERSION}.tar.gz
+    curl -O https://www.libssh2.org/download/libssh2-${VERSION}.tar.gz
 else
 	echo "Using libssh2-${VERSION}.tar.gz"
 fi


### PR DESCRIPTION
I needed this to be able to build; otherwise the downloaded .tar.gz is actually an HTML file containing a redirect.